### PR TITLE
Use HTTPS instead of HTTP for Dependencies

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,10 +15,10 @@
   <div ng-view></div>
 
   <!-- angular -->
-  <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
-  <script src="http://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-route.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-route.js"></script>
   <!-- jQuery -->
-  <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
 
   <!-- code -->
   <script src="app.js"></script>


### PR DESCRIPTION
## Summary
As the title of this PR suggests, the changes cover using HTTPS instead of HTTP when importing Angular and jQuery dependencies.

@mahtabsabet It seems like you are the only maintainer of this repo, I'd appreciate it if you reviewed this.

## Reasoning
Game is unplayable on:
- Chrome `Version 86.0.4240.198 (Official Build) (x86_64)`
- Safari `Version 14.0 (15610.1.28.1.9, 15610)`

Console errors received are:
```
Mixed Content: The page at 'https://farmclicker.github.io/' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular.min.js'. This request has been blocked; the content must be served over HTTPS.
Mixed Content: The page at 'https://farmclicker.github.io/' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/angularjs/1.3.15/angular-route.js'. This request has been blocked; the content must be served over HTTPS.
Mixed Content: The page at 'https://farmclicker.github.io/' was loaded over HTTPS, but requested an insecure script 'http://ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js'. This request has been blocked; the content must be served over HTTPS.
```